### PR TITLE
Update readme cleanup explanation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Get the root temporary directory path. For example: `/private/var/folders/3x/jf5
 
 ### Why doesn't it have a cleanup method?
 
-Temp files will be periodically cleaned up on Mac OS. If you're generating a lot of tmp files, it's recommended to use a complementary module like [rimraf](https://github.com/isaacs/rimraf) for cleanup.
+Temp files will be periodically cleaned up on macOS. If you're generating a lot of tmp files, it's recommended to use a complementary module like [`rimraf`](https://github.com/isaacs/rimraf) for cleanup.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Get the root temporary directory path. For example: `/private/var/folders/3x/jf5
 
 ### Why doesn't it have a cleanup method?
 
-The operating system will clean up when needed. No point in us wasting resources and adding complexity.
+Temp files will be periodically cleaned up on Mac OS. If you're generating a lot of tmp files, it's recommended to use a complementary module like [rimraf](https://github.com/isaacs/rimraf) for cleanup.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Get the root temporary directory path. For example: `/private/var/folders/3x/jf5
 
 ### Why doesn't it have a cleanup method?
 
-Temp files will be periodically cleaned up on macOS. If you're generating a lot of tmp files, it's recommended to use a complementary module like [`rimraf`](https://github.com/isaacs/rimraf) for cleanup.
+Temp files will be periodically cleaned up on macOS. Most Linux distros will clean up on reboot. If you're generating a lot of temp files, it's recommended to use a complementary module like [`rimraf`](https://github.com/isaacs/rimraf) for cleanup.
 
 
 ## Related


### PR DESCRIPTION
As noted in #4, the current explanation for not including a `cleanup` method is misleading. 

I agree that it's overkill to include a cleanup method in this module, but given this is a common use case, I think linking to the most used node `rmrf` module, [rimraf](https://github.com/isaacs/rimraf) seems like a reasonable addition.

---

Fixes #4