### PR TITLE
Fix issue #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-const fs = require('fs');
 const path = require('path');
+const mkdirp = require('mkdirp');
 const uniqueString = require('unique-string');
 const tempDir = require('temp-dir');
 
@@ -22,9 +22,13 @@ module.exports.file = opts => {
 	return getPath() + '.' + opts.extension.replace(/^\./, '');
 };
 
-module.exports.directory = () => {
-	const dir = getPath();
-	fs.mkdirSync(dir);
+module.exports.directory = opts => {
+	opts = Object.assign({
+		prefix: ''
+	}, opts);
+
+	const dir = path.join(tempDir, opts.prefix + uniqueString());
+	mkdirp.sync(dir);
 	return dir;
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"uniq"
 	],
 	"dependencies": {
+		"mkdirp": "^0.5.1",
 		"temp-dir": "^1.0.0",
 		"unique-string": "^1.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,9 @@ tempy.file({name: 'unicorn.png'});
 
 tempy.directory();
 //=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+
+tempy.directory({prefix: 'custom'});
+//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/custom21524d18f6d084ce97a250d6b300908e'
 ```
 
 
@@ -53,9 +56,19 @@ Type: `string`
 
 Filename. Mutually exclusive with the `extension` option.
 
-### tempy.directory()
+### tempy.directory([options])
 
 Get a temporary directory path. The directory is created for you.
+
+#### options
+
+Type: `Object`
+
+##### prefix
+
+Type: `string`
+
+The directory will start with this.
 
 ### tempy.root
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import {tmpdir} from 'os';
 import test from 'ava';
+import uniqueString from 'unique-string';
 import tempy from '.';
 
 test('.file()', t => {
@@ -12,7 +13,11 @@ test('.file()', t => {
 });
 
 test('.directory()', t => {
+	const subDir = uniqueString();
+
 	t.true(tempy.directory().includes(tmpdir()));
+	t.true(tempy.directory({prefix: 'custom'}).includes('custom'));
+	t.true(tempy.directory({prefix: subDir + '\\'}).includes(subDir));
 });
 
 test('.root', t => {


### PR DESCRIPTION
`tempy.directory()` now accepts an options object. One option is currently available: `prefix` which is a string. This string will be pre-pended to the unique string when creating the directory.