### PR TITLE
Add cleanup methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,16 +128,6 @@ declare const tempy: {
 	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `function` is finished.
 	@returns Task output
 
-	@example
-	```
-	import pathExists = require('path-exists');
-	import tempy = require('tempy');
-
-	(() => {
-		console.log(tempy.job(directory => pathExists(directory)));
-		//=> true
-	})();
-	```
 	*/
 	job(task: (directory: string) => unknown): unknown;
 
@@ -149,12 +139,18 @@ declare const tempy: {
 
 	@example
 	```
-	import pathExists = require('path-exists');
+	import  path = require('path');
 	import tempy = require('tempy');
+	import  download = require('download');
+	import  wallpaper = require('wallpaper');
 
 	(async () => {
-		console.log(await tempy.jobAsync(directory => pathExists(directory)));
-		//=> true
+		console.log(await tempy.jobAsync(async directory => {
+			await download('http://unicorn.com/foo.jpg', directory, {filename: 'unicorn.jpg'});
+			await wallpaper.set(path.join(directory, 'unicorn.jpg'));
+			return 'done!';
+		}));
+		//=> 'done!'
 	})();
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare const tempy: {
 	@example
 	```
 	import tempy = require('tempy');
+	import pathExists = require('path-exists');
 
 	tempy.file();
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd'
@@ -40,6 +41,14 @@ declare const tempy: {
 
 	tempy.directory();
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+
+	tempy.clean();
+	//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
+
+	(async () => {
+		console.log(await tempy.job(directory => pathExists(directory)));
+		//=> true
+	})();
 	```
 	*/
 	file(options?: tempy.Options): string;
@@ -56,6 +65,21 @@ declare const tempy: {
 	```
 	*/
 	directory(): string;
+
+	/**
+	Deletes temporary directories and returns an array of deleted path.
+
+	@returns An array of deleted paths.
+	*/
+	clean(): string[];
+
+	/**
+	Returns a `Promise` for value obtained in `task`.
+
+	@returns Task output
+	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
+	*/
+	job(task: (directory: string) => unknown): Promise<unknown>;
 
 	/**
 	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ declare const tempy: {
 	directoryAsync(): Promise<string>;
 
 	/**
-	Deletes temporary directories and returns an array of deleted path.
+	Get a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
 	@returns An array of deleted paths.
 
@@ -106,7 +106,7 @@ declare const tempy: {
 	clean(): string[];
 
 	/**
-	Returns a `Promise` with deletes temporary directories and returns an array of deleted path.
+	Returns a `Promise` with a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
 	@returns An array of deleted paths.
 
@@ -125,7 +125,7 @@ declare const tempy: {
 	/**
 	Returns the value obtained in `task`.
 
-	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `function` is finished.
+	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Function` is finished.
 	@returns Task output
 
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,27 @@ declare const tempy: {
 	file(options?: tempy.Options): string;
 
 	/**
+	Returns a `Promise` with a temporary file path you can write to.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	(async () => {
+		await tempy.fileAsync();
+		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd'
+
+		await tempy.fileAsync({extension: 'png'});
+		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/a9fb0decd08179eb6cf4691568aa2018.png'
+
+		await tempy.fileAsync({name: 'unicorn.png'});
+		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/unicorn.png'
+	})();
+	```
+	*/
+	fileAsync(options?: tempy.Options): Promise<string>;
+
+	/**
 	Get a temporary directory path. The directory is created for you.
 
 	@example
@@ -53,6 +74,21 @@ declare const tempy: {
 	```
 	*/
 	directory(): string;
+
+	/**
+	Returns a `Promise` with a temporary directory path. The directory is created for you.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	(async () => {
+		await tempy.directoryAsync();
+		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+	})();
+	```
+	*/
+	directoryAsync(): Promise<string>;
 
 	/**
 	Deletes temporary directories and returns an array of deleted path.
@@ -70,6 +106,42 @@ declare const tempy: {
 	clean(): string[];
 
 	/**
+	Returns a `Promise` with deletes temporary directories and returns an array of deleted path.
+
+	@returns An array of deleted paths.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	(async () => {
+		await empy.cleanAsync();
+		//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
+	})();
+	```
+	*/
+	cleanAsync(): Promise<string[]>;
+
+	/**
+	Returns the value obtained in `task`.
+
+	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `function` is finished.
+	@returns Task output
+
+	@example
+	```
+	import pathExists = require('path-exists');
+	import tempy = require('tempy');
+
+	(() => {
+		console.log(tempy.job(directory => pathExists(directory)));
+		//=> true
+	})();
+	```
+	*/
+	job(task: (directory: string) => unknown): unknown;
+
+	/**
 	Returns a `Promise` for value obtained in `task`.
 
 	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
@@ -81,12 +153,24 @@ declare const tempy: {
 	import tempy = require('tempy');
 
 	(async () => {
-		console.log(await tempy.job(directory => pathExists(directory)));
+		console.log(await tempy.jobAsync(directory => pathExists(directory)));
 		//=> true
 	})();
 	```
 	*/
-	job(task: (directory: string) => unknown): Promise<unknown>;
+	jobAsync(task: (directory: string) => unknown): Promise<unknown>;
+
+	/**
+	Disable auto cleaning directories
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	tempy.disableAutoClean()
+	```
+	*/
+	disableAutoClean(): void;
 
 	/**
 	Get the root temporary directory path.

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,7 +129,7 @@ declare const tempy: {
 	@returns Task output
 
 	*/
-	job(task: (directory: string) => unknown): unknown;
+	jobDirectory(task: (directory: string) => unknown): unknown;
 
 	/**
 	Returns a `Promise` for value obtained in `task`.
@@ -145,7 +145,7 @@ declare const tempy: {
 	import  wallpaper = require('wallpaper');
 
 	(async () => {
-		console.log(await tempy.jobAsync(async directory => {
+		console.log(await tempy.jobDirectoryAsync(async directory => {
 			await download('http://unicorn.com/foo.jpg', directory, {filename: 'unicorn.jpg'});
 			await wallpaper.set(path.join(directory, 'unicorn.jpg'));
 			return 'done!';
@@ -154,7 +154,25 @@ declare const tempy: {
 	})();
 	```
 	*/
-	jobAsync(task: (directory: string) => unknown): Promise<unknown>;
+	jobDirectoryAsnc(task: (directory: string) => unknown): Promise<unknown>;
+
+	/**
+	Returns the value obtained in `task`.
+
+	@param task - A function that will be called with a temporary file path. The file is created and deleted when `Function` is finished.
+	@returns Task output
+
+	*/
+	jobFile(task: (file: string) => unknown, options?: tempy.Options): unknown;
+
+	/**
+	Returns a `Promise` for value obtained in `task`.
+
+	@param task - A function that will be called with a temporary file path. The file is created and deleted when `Promise` is resolved.
+	@returns Task output
+
+	*/
+	jobFileAsync(task: (direcfiletory: string) => unknown, options?: tempy.Options): Promise<unknown>;
 
 	/**
 	Disable auto cleaning directories

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,6 @@ declare const tempy: {
 	@example
 	```
 	import tempy = require('tempy');
-	import pathExists = require('path-exists');
 
 	tempy.file();
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd'
@@ -38,17 +37,6 @@ declare const tempy: {
 
 	tempy.file({name: 'unicorn.png'});
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/unicorn.png'
-
-	tempy.directory();
-	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
-
-	tempy.clean();
-	//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
-
-	(async () => {
-		console.log(await tempy.job(directory => pathExists(directory)));
-		//=> true
-	})();
 	```
 	*/
 	file(options?: tempy.Options): string;
@@ -70,19 +58,46 @@ declare const tempy: {
 	Deletes temporary directories and returns an array of deleted path.
 
 	@returns An array of deleted paths.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	tempy.clean();
+	//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
+	```
 	*/
 	clean(): string[];
 
 	/**
 	Returns a `Promise` for value obtained in `task`.
 
-	@returns Task output
 	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
+	@returns Task output
+
+	@example
+	```
+	import pathExists = require('path-exists');
+	import tempy = require('tempy');
+
+	(async () => {
+		console.log(await tempy.job(directory => pathExists(directory)));
+		//=> true
+	})();
+	```
 	*/
 	job(task: (directory: string) => unknown): Promise<unknown>;
 
 	/**
-	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.
+	Get the root temporary directory path.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	tempy.root;
+	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T'
+	```
 	*/
 	readonly root: string;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,21 @@
-import {MergeExclusive} from 'type-fest';
+/// <reference types="node"/>
+import {MergeExclusive, TypedArray} from 'type-fest';
 
 declare namespace tempy {
 	type Options = MergeExclusive<
 		{
 			/**
+			File extension.
+			Mutually exclusive with the `name` option.
 			_You usually won't need this option. Specify it only when actually needed._
-
-			File extension. Mutually exclusive with the `name` option.
 			*/
 			readonly extension?: string;
 		},
 		{
 			/**
+			Filename.
+			Mutually exclusive with the `extension` option.
 			_You usually won't need this option. Specify it only when actually needed._
-
-			Filename. Mutually exclusive with the `extension` option.
 			*/
 			readonly name?: string;
 		}
@@ -54,7 +55,7 @@ declare const tempy: {
 
 		await tempy.fileAsync({extension: 'png'});
 		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/a9fb0decd08179eb6cf4691568aa2018.png'
-
+		
 		await tempy.fileAsync({name: 'unicorn.png'});
 		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/unicorn.png'
 	})();
@@ -64,11 +65,9 @@ declare const tempy: {
 
 	/**
 	Get a temporary directory path. The directory is created for you.
-
 	@example
 	```
 	import tempy = require('tempy');
-
 	tempy.directory();
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
 	```
@@ -77,11 +76,9 @@ declare const tempy: {
 
 	/**
 	Returns a `Promise` with a temporary directory path. The directory is created for you.
-
 	@example
 	```
 	import tempy = require('tempy');
-
 	(async () => {
 		await tempy.directoryAsync();
 		//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
@@ -91,14 +88,33 @@ declare const tempy: {
 	directoryAsync(): Promise<string>;
 
 	/**
-	Get a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
-
-	@returns An array of deleted paths.
-
+	Write data to a random temp file.
 	@example
 	```
 	import tempy = require('tempy');
+	await tempy.write('🦄');
+	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+	```
+	*/
+	write(fileContent: string | Buffer | TypedArray | DataView | NodeJS.ReadableStream, options?: tempy.Options): Promise<string>;
 
+	/**
+	Synchronously write data to a random temp file.
+	@example
+	```
+	import tempy = require('tempy');
+	tempy.writeSync('🦄');
+	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+	```
+	*/
+	writeSync(fileContent: string | Buffer | TypedArray | DataView, options?: tempy.Options): string;
+
+	/**
+	Get a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
+	@returns An array of deleted paths.
+	@example
+	```
+	import tempy = require('tempy');
 	tempy.clean();
 	//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
 	```
@@ -107,13 +123,10 @@ declare const tempy: {
 
 	/**
 	Returns a `Promise` with a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
-
 	@returns An array of deleted paths.
-
 	@example
 	```
 	import tempy = require('tempy');
-
 	(async () => {
 		await empy.cleanAsync();
 		//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
@@ -124,26 +137,21 @@ declare const tempy: {
 
 	/**
 	Returns the value obtained in `task`.
-
 	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Function` is finished.
 	@returns Task output
-
 	*/
 	jobDirectory(task: (directory: string) => unknown): unknown;
 
 	/**
 	Returns a `Promise` for value obtained in `task`.
-
 	@param task - A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
 	@returns Task output
-
 	@example
 	```
 	import  path = require('path');
 	import tempy = require('tempy');
 	import  download = require('download');
 	import  wallpaper = require('wallpaper');
-
 	(async () => {
 		console.log(await tempy.jobDirectoryAsync(async directory => {
 			await download('http://unicorn.com/foo.jpg', directory, {filename: 'unicorn.jpg'});
@@ -158,29 +166,23 @@ declare const tempy: {
 
 	/**
 	Returns the value obtained in `task`.
-
 	@param task - A function that will be called with a temporary file path. The file is created and deleted when `Function` is finished.
 	@returns Task output
-
 	*/
 	jobFile(task: (file: string) => unknown, options?: tempy.Options): unknown;
 
 	/**
 	Returns a `Promise` for value obtained in `task`.
-
 	@param task - A function that will be called with a temporary file path. The file is created and deleted when `Promise` is resolved.
 	@returns Task output
-
 	*/
 	jobFileAsync(task: (direcfiletory: string) => unknown, options?: tempy.Options): Promise<unknown>;
 
 	/**
 	Disable auto cleaning directories
-
 	@example
 	```
 	import tempy = require('tempy');
-
 	tempy.disableAutoClean()
 	```
 	*/
@@ -188,14 +190,7 @@ declare const tempy: {
 
 	/**
 	Get the root temporary directory path.
-
-	@example
-	```
-	import tempy = require('tempy');
-
-	tempy.root;
-	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T'
-	```
+	For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.
 	*/
 	readonly root: string;
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const uniqueString = require('unique-string');
 const tempDir = require('temp-dir');
 const del = require('del');
 
-const cacheDirectories = [];
+let cacheDirectories = [];
 
 const getPath = () => {
 	const directory = path.join(tempDir, uniqueString());
@@ -33,7 +33,11 @@ module.exports.file = options => {
 
 module.exports.directory = getPath;
 
-module.exports.clean = () => del.sync(cacheDirectories.map(directory => directory + '/**'), {force: true});
+module.exports.clean = () => {
+	const deletedDirectories = del.sync(cacheDirectories.map(directory => directory + '/**'), {force: true});
+	cacheDirectories = [];
+	return deletedDirectories;
+};
 
 module.exports.job = async fn => {
 	if (typeof fn !== 'function') {

--- a/index.js
+++ b/index.js
@@ -1,15 +1,23 @@
 'use strict';
-const fs = require('fs');
 const path = require('path');
 const uniqueString = require('unique-string');
 const tempDir = require('temp-dir');
 const del = require('del');
+const makeDir = require('make-dir');
+const exitHook = require('exit-hook');
 
 let cacheDirectories = [];
 
 const getPath = () => {
 	const directory = path.join(tempDir, uniqueString());
-	fs.mkdirSync(directory);
+	makeDir.sync(directory);
+	cacheDirectories.push(directory);
+	return directory;
+};
+
+const getPathAsync = async () => {
+	const directory = path.join(tempDir, uniqueString());
+	await makeDir(directory);
 	cacheDirectories.push(directory);
 	return directory;
 };
@@ -31,22 +39,60 @@ module.exports.file = options => {
 	return getPath() + '.' + options.extension.replace(/^\./, '');
 };
 
+module.exports.fileAsync = async options => {
+	options = {
+		extension: '',
+		...options
+	};
+
+	if (options.name) {
+		if (options.extension) {
+			throw new Error('The `name` and `extension` options are mutually exclusive');
+		}
+
+		const directory = await getPathAsync();
+		return path.join(directory, options.name);
+	}
+
+	const directory = await getPathAsync();
+	return directory + '.' + options.extension.replace(/^\./, '');
+};
+
 module.exports.directory = getPath;
 
+module.exports.directoryAsync = getPathAsync;
+
 module.exports.clean = () => {
-	const deletedDirectories = del.sync(cacheDirectories.map(directory => directory + '/**'), {force: true});
+	const deletedDirectories = del.sync(cacheDirectories, {force: true});
 	cacheDirectories = [];
 	return deletedDirectories;
 };
 
-module.exports.job = async fn => {
+module.exports.cleanAsync = async () => {
+	const deletedDirectories = await del(cacheDirectories, {force: true});
+	cacheDirectories = [];
+	return deletedDirectories;
+};
+
+module.exports.job = fn => {
+	if (typeof fn !== 'function') {
+		throw new TypeError('Expected a function');
+	}
+
+	const directory = getPath();
+	const output = fn(directory);
+	del.sync(directory, {force: true});
+	return output;
+};
+
+module.exports.jobAsync = async fn => {
 	if (typeof fn !== 'function') {
 		throw new TypeError('Expected a function');
 	}
 
 	const directory = getPath();
 	const output = await fn(directory);
-	await del(directory + '/**', {force: true});
+	await del(directory, {force: true});
 	return output;
 };
 
@@ -56,4 +102,4 @@ Object.defineProperty(module.exports, 'root', {
 	}
 });
 
-process.on('exit', module.exports.clean);
+module.exports.disableAutoClean = exitHook(module.exports.clean);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const del = require('del');
 const makeDir = require('make-dir');
 const exitHook = require('exit-hook');
 
-let cacheDirectories = [];
+const cacheDirectories = [];
 
 const getPath = () => {
 	const directory = path.join(tempDir, uniqueString());
@@ -20,6 +20,15 @@ const getPathAsync = async () => {
 	await makeDir(directory);
 	cacheDirectories.push(directory);
 	return directory;
+};
+
+const removeCacheDirectories = directoryToRemove => {
+	directoryToRemove.forEach(directory => {
+		const index = cacheDirectories.indexOf(directory);
+		if (index > -1) {
+			cacheDirectories.splice(index, 1);
+		}
+	});
 };
 
 module.exports.file = options => {
@@ -64,13 +73,13 @@ module.exports.directoryAsync = getPathAsync;
 
 module.exports.clean = () => {
 	const deletedDirectories = del.sync(cacheDirectories, {force: true});
-	cacheDirectories = [];
+	removeCacheDirectories(deletedDirectories);
 	return deletedDirectories;
 };
 
 module.exports.cleanAsync = async () => {
 	const deletedDirectories = await del(cacheDirectories, {force: true});
-	cacheDirectories = [];
+	removeCacheDirectories(deletedDirectories);
 	return deletedDirectories;
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,6 +9,9 @@ expectType<string>(tempy.file({name: 'afile.txt'}));
 expectType<string[]>(tempy.clean());
 expectType<unknown>(tempy.jobDirectory(() => {}));
 expectType<unknown>(tempy.jobFile(() => {}));
+expectType<string>(tempy.writeSync('unicorn'));
+expectType<string>(tempy.writeSync(Buffer.from('unicorn')));
+expectType<string>(tempy.writeSync('unicorn', {name: 'pony.png'}));
 
 expectType<Promise<string>>(tempy.directoryAsync());
 expectType<Promise<string>>(tempy.fileAsync());
@@ -17,6 +20,10 @@ expectType<Promise<string>>(tempy.fileAsync({name: 'afile.txt'}));
 expectType<Promise<string[]>>(tempy.cleanAsync());
 expectType<Promise<unknown>>(tempy.jobDirectoryAsnc(async () => {}));
 expectType<Promise<unknown>>(tempy.jobFileAsync(async () => {}));
+expectType<Promise<string>>(tempy.write('unicorn'));
+expectType<Promise<string>>(tempy.write('unicorn', {name: 'pony.png'}));
+expectType<Promise<string>>(tempy.write(process.stdin, {name: 'pony.png'}));
+expectType<Promise<string>>(tempy.write(Buffer.from('pony'), {name: 'pony.png'}));
 
 expectType<void>(tempy.disableAutoClean());
 expectType<string>(tempy.root);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,14 +6,18 @@ expectType<string>(tempy.directory());
 expectType<string>(tempy.file());
 expectType<string>(tempy.file({extension: 'png'}));
 expectType<string>(tempy.file({name: 'afile.txt'}));
-expectType<string>(tempy.root);
 expectType<string[]>(tempy.clean());
+expectType<unknown>(tempy.job(() => {}));
 
-expectType<Promise<unknown>>(tempy.job(() => {}));
-expectType<Promise<unknown>>(tempy.job(() => true));
-expectType<Promise<unknown>>(tempy.job(async () => 'done!'));
-expectType<Promise<unknown>>(tempy.job(directory => directory));
-expectType<Promise<unknown>>(tempy.job(async directory => directory));
+expectType<Promise<string>>(tempy.directoryAsync());
+expectType<Promise<string>>(tempy.fileAsync());
+expectType<Promise<string>>(tempy.fileAsync({extension: 'png'}));
+expectType<Promise<string>>(tempy.fileAsync({name: 'afile.txt'}));
+expectType<Promise<string[]>>(tempy.cleanAsync());
+expectType<Promise<unknown>>(tempy.jobAsync(async () => {}));
+
+expectType<void>(tempy.disableAutoClean());
+expectType<string>(tempy.root);
 
 expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
 expectError(tempy.job('string'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,14 +7,16 @@ expectType<string>(tempy.file());
 expectType<string>(tempy.file({extension: 'png'}));
 expectType<string>(tempy.file({name: 'afile.txt'}));
 expectType<string[]>(tempy.clean());
-expectType<unknown>(tempy.job(() => {}));
+expectType<unknown>(tempy.jobDirectory(() => {}));
+expectType<unknown>(tempy.jobFile(() => {}));
 
 expectType<Promise<string>>(tempy.directoryAsync());
 expectType<Promise<string>>(tempy.fileAsync());
 expectType<Promise<string>>(tempy.fileAsync({extension: 'png'}));
 expectType<Promise<string>>(tempy.fileAsync({name: 'afile.txt'}));
 expectType<Promise<string[]>>(tempy.cleanAsync());
-expectType<Promise<unknown>>(tempy.jobAsync(async () => {}));
+expectType<Promise<unknown>>(tempy.jobDirectoryAsnc(async () => {}));
+expectType<Promise<unknown>>(tempy.jobFileAsync(async () => {}));
 
 expectType<void>(tempy.disableAutoClean());
 expectType<string>(tempy.root);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,5 +6,14 @@ expectType<string>(tempy.directory());
 expectType<string>(tempy.file());
 expectType<string>(tempy.file({extension: 'png'}));
 expectType<string>(tempy.file({name: 'afile.txt'}));
-expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
 expectType<string>(tempy.root);
+expectType<string[]>(tempy.clean());
+
+expectType<Promise<unknown>>(tempy.job(() => {}));
+expectType<Promise<unknown>>(tempy.job(() => true));
+expectType<Promise<unknown>>(tempy.job(async () => 'done!'));
+expectType<Promise<unknown>>(tempy.job(directory => directory));
+expectType<Promise<unknown>>(tempy.job(async directory => directory));
+
+expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
+expectError(tempy.job('string'));

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
 		"uniq"
 	],
 	"dependencies": {
+		"del": "^4.1.1",
 		"temp-dir": "^1.0.0",
 		"type-fest": "^0.3.1",
 		"unique-string": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
+		"path-exists": "^4.0.0",
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 	],
 	"dependencies": {
 		"del": "^4.1.1",
+		"exit-hook": "^2.2.0",
+		"make-dir": "^3.0.0",
 		"temp-dir": "^1.0.0",
 		"type-fest": "^0.3.1",
 		"unique-string": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
 	"name": "tempy",
-	"version": "0.3.0",
+	"version": "0.5.0",
 	"description": "Get a random temporary file or directory path",
 	"license": "MIT",
 	"repository": "sindresorhus/tempy",
+	"funding": "https://github.com/sponsors/sindresorhus",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
+		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -31,21 +32,21 @@
 		"tmpdir",
 		"tmpfile",
 		"random",
-		"unique",
-		"uniq"
+		"unique"
 	],
 	"dependencies": {
 		"del": "^4.1.1",
 		"exit-hook": "^2.2.0",
 		"make-dir": "^3.0.0",
-		"temp-dir": "^1.0.0",
-		"type-fest": "^0.3.1",
-		"unique-string": "^1.0.0"
+		"path-exists": "^4.0.0",
+		"is-stream": "^2.0.0",
+		"temp-dir": "^2.0.0",
+		"type-fest": "^0.12.0",
+		"unique-string": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
-		"path-exists": "^4.0.0",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
+		"tsd": "^0.11.0",
+		"xo": "^0.25.4"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ $ npm install tempy
 ## Usage
 
 ```js
+const pathExists = require('path-exists');
 const tempy = require('tempy');
 
 tempy.file();
@@ -26,8 +27,17 @@ tempy.file({name: 'unicorn.png'});
 
 tempy.directory();
 //=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+
+tempy.clean();
+//=> ['/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd', ...]
+
+(async () => {
+	console.log(await tempy.job(directory => pathExists(directory)));
+	//=> true
+})();
 ```
 
+**Note:** Cleaning of temporary directories runs automatically when the process exits.
 
 ## API
 
@@ -57,10 +67,25 @@ Filename. Mutually exclusive with the `extension` option.
 
 Get a temporary directory path. The directory is created for you.
 
+### tempy.clean()
+
+Type: `string[]`
+
+Deletes temporary directories and returns an array of deleted path.
+
+### tempy.job(task)
+
+Returns a `Promise` for value obtained in `task`.
+
+#### task
+
+Type: `Function`
+
+A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
+
 ### tempy.root
 
 Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`
-
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,11 @@
 
 > Get a random temporary file or directory path
 
-
 ## Install
 
 ```
 $ npm install tempy
 ```
-
 
 ## Usage
 
@@ -50,17 +48,35 @@ tempy.clean();
 
 ## API
 
-### tempy.file([options])
+### tempy.file(options?)
 
 Get a temporary file path you can write to.
 
-### tempy.fileAsync([options])
+#### options
+
+Type: `object`
+
+*You usually won't need either the `extension` or `name` option. Specify them only when actually needed.*
+
+##### extension
+
+Type: `string`
+
+File extension.
+
+##### name
+
+Type: `string`
+
+Filename. Mutually exclusive with the `extension` option.
+
+### tempy.fileAsync(options?)
 
 Returns a `Promise` with a temporary file path you can write to.
 
 #### options
 
-Type: `Object`
+Type: `object`
 
 *You usually won't need either the `extension` or `name` option. Specify them only when actually needed.*
 
@@ -84,6 +100,34 @@ Get a temporary directory path. The directory is created for you.
 
 Returns a `Promise` with a temporary directory path. The directory is created for you.
 
+### tempy.write(fileContent, options?)
+
+Write data to a random temp file.
+
+##### fileContent
+
+Type: `string | Buffer | TypedArray | DataView | stream.Readable`
+
+Data to write to the temp file.
+
+##### options
+
+See [options](#options).
+
+### tempy.writeSync(fileContent, options?)
+
+Synchronously write data to a random temp file.
+
+##### fileContent
+
+Type: `string | Buffer | TypedArray | DataView`
+
+Data to write to the temp file.
+
+##### options
+
+See [options](#options).
+
 ### tempy.clean()
 
 Get a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
@@ -92,11 +136,35 @@ Get a list of deleted temporary directories and clears them. This is useful for 
 
 Returns a `Promise` with a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
-### tempy.jobFile(task, [options])
+### tempy.jobFile(task, options?)
 
 Returns the value obtained in `task`.
 
-### tempy.jobFileAsync(task, [options])
+#### task
+
+Type: `Function`
+
+A function that will be called with a temporary file path. The file is created and deleted when `Function` is finished.
+
+#### options
+
+Type: `Object`
+
+*You usually won't need either the `extension` or `name` option. Specify them only when actually needed.*
+
+##### extension
+
+Type: `string`
+
+File extension.
+
+##### name
+
+Type: `string`
+
+Filename. Mutually exclusive with the `extension` option.
+
+### tempy.jobFileAsync(task, options?)
 
 Returns a `Promise` for value obtained in `task`.
 
@@ -128,6 +196,12 @@ Filename. Mutually exclusive with the `extension` option.
 
 Returns the value obtained in `task`.
 
+#### task
+
+Type: `Function`
+
+A function that will be called with a temporary directory path. The directory is created and deleted when `Function` is finished.
+
 ### tempy.jobDirectoryAsync(task)
 
 Returns a `Promise` for value obtained in `task`.
@@ -145,19 +219,3 @@ Disable auto cleaning directories
 ### tempy.root
 
 Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`
-
-## FAQ
-
-### Why doesn't it have a cleanup method?
-
-Temp files will be periodically cleaned up on macOS. Most Linux distros will clean up on reboot. If you're generating a lot of temp files, it's recommended to use a complementary module like [`rimraf`](https://github.com/isaacs/rimraf) for cleanup.
-
-
-## Related
-
-- [temp-write](https://github.com/sindresorhus/temp-write) - Write string/buffer/stream to a random temp file
-
-
-## License
-
-MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,10 @@ $ npm install tempy
 ## Usage
 
 ```js
-const pathExists = require('path-exists');
 const tempy = require('tempy');
+const download = require('download');
+const wallpaper = require('wallpaper');
+const pathExists = require('path-exists');
 
 tempy.file();
 //=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd'
@@ -34,6 +36,13 @@ tempy.clean();
 (async () => {
 	console.log(await tempy.job(directory => pathExists(directory)));
 	//=> true
+
+	console.log(await tempy.jobDirectoryAsync(async directory => {
+		await download('http://unicorn.com/foo.jpg', directory, {filename: 'unicorn.jpg'});
+		await wallpaper.set(path.join(directory, 'unicorn.jpg'));
+		return 'done!';
+	}));
+	//=> 'done!'
 })();
 ```
 
@@ -83,11 +92,43 @@ Get a list of deleted temporary directories and clears them. This is useful for 
 
 Returns a `Promise` with a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
-### tempy.job(task)
+### tempy.jobFile(task, [options])
 
 Returns the value obtained in `task`.
 
-### tempy.jobAsync(task)
+### tempy.jobFileAsync(task, [options])
+
+Returns a `Promise` for value obtained in `task`.
+
+#### task
+
+Type: `Function`
+
+A function that will be called with a temporary file path. The file is created and deleted when `Function` is finished.
+
+#### options
+
+Type: `Object`
+
+*You usually won't need either the `extension` or `name` option. Specify them only when actually needed.*
+
+##### extension
+
+Type: `string`
+
+File extension.
+
+##### name
+
+Type: `string`
+
+Filename. Mutually exclusive with the `extension` option.
+
+### tempy.jobDirectory(task)
+
+Returns the value obtained in `task`.
+
+### tempy.jobDirectoryAsync(task)
 
 Returns a `Promise` for value obtained in `task`.
 

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,10 @@ tempy.clean();
 
 Get a temporary file path you can write to.
 
+### tempy.fileAsync([options])
+
+Returns a `Promise` with a temporary file path you can write to.
+
 #### options
 
 Type: `Object`
@@ -67,13 +71,23 @@ Filename. Mutually exclusive with the `extension` option.
 
 Get a temporary directory path. The directory is created for you.
 
+### tempy.directoryAsync()
+
+Returns a `Promise` with a temporary directory path. The directory is created for you.
+
 ### tempy.clean()
 
-Type: `string[]`
+Get a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
-Deletes temporary directories and returns an array of deleted path.
+### tempy.cleanAsync()
+
+Returns a `Promise` with a list of deleted temporary directories and clears them. This is useful for when auto cleanup is disabled or when there are lots of temp files.
 
 ### tempy.job(task)
+
+Returns the value obtained in `task`.
+
+### tempy.jobAsync(task)
 
 Returns a `Promise` for value obtained in `task`.
 
@@ -81,7 +95,11 @@ Returns a `Promise` for value obtained in `task`.
 
 Type: `Function`
 
-A function that will be called with a temporary directory path. The directory is created and deleted when `Promise` is resolved.
+A function that will be called with a temporary directory path. The directory is created and deleted when `Function` is finished.
+
+### tempy.disableAutoClean()
+
+Disable auto cleaning directories
 
 ### tempy.root
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import {tmpdir} from 'os';
 import test from 'ava';
+import pathExists from 'path-exists';
 import tempy from '.';
 
 test('.file()', t => {
@@ -13,6 +14,22 @@ test('.file()', t => {
 
 test('.directory()', t => {
 	t.true(tempy.directory().includes(tmpdir()));
+});
+
+test('.clean()', t => {
+	const deleleDirectories = tempy.clean();
+	t.true(deleleDirectories.length > 0);
+	deleleDirectories.forEach(directory => {
+		t.false(pathExists.sync(directory));
+	});
+});
+
+test('.job()', async t => {
+	t.true(await tempy.job(async directory => pathExists(directory)));
+	t.true(await tempy.job(directory => pathExists.sync(directory)));
+
+	const deleleDirectory = await tempy.job(directory => directory);
+	t.false(await pathExists(deleleDirectory));
 });
 
 test('.root', t => {

--- a/test.js
+++ b/test.js
@@ -1,15 +1,36 @@
 import path from 'path';
 import {tmpdir} from 'os';
+import fs from 'fs';
+import stream from 'stream';
 import test from 'ava';
 import pathExists from 'path-exists';
 import tempy from '.';
 
 test('.file()', t => {
 	t.true(tempy.file().includes(tmpdir()));
+	t.false(tempy.file().endsWith('.'));
+	t.false(tempy.file({extension: undefined}).endsWith('.'));
+	t.false(tempy.file({extension: null}).endsWith('.'));
 	t.true(tempy.file({extension: 'png'}).endsWith('.png'));
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
+
+	t.throws(() => {
+		tempy.file({name: 'custom-name.md', extension: '.ext'});
+	});
+
+	t.throws(() => {
+		tempy.file({name: 'custom-name.md', extension: ''});
+	});
+
+	t.notThrows(() => {
+		tempy.file({name: 'custom-name.md', extension: undefined});
+	});
+
+	t.notThrows(() => {
+		tempy.file({name: 'custom-name.md', extension: null});
+	});
 });
 
 test('.fileAsync()', async t => {
@@ -76,9 +97,50 @@ test('.jobFileAsync()', async t => {
 	t.false(await pathExists(deleleDirectory));
 });
 
+test('.write(string)', async t => {
+	const filePath = await tempy.write('unicorn', {name: 'test.png'});
+	t.is(fs.readFileSync(filePath, 'utf8'), 'unicorn');
+	t.is(path.basename(filePath), 'test.png');
+});
+
+test('.write(buffer)', async t => {
+	const filePath = await tempy.write(Buffer.from('unicorn'));
+	t.is(fs.readFileSync(filePath, 'utf8'), 'unicorn');
+});
+
+test('.write(stream)', async t => {
+	const readable = new stream.Readable({
+		read() {}
+	});
+	readable.push('unicorn');
+	readable.push(null);
+	const filePath = await tempy.write(readable);
+	t.is(fs.readFileSync(filePath, 'utf8'), 'unicorn');
+});
+
+test('.write(stream) failing stream', async t => {
+	const readable = new stream.Readable({
+		read() {}
+	});
+	readable.push('unicorn');
+	setImmediate(() => {
+		readable.emit('error', new Error('Catch me if you can!'));
+		readable.push(null);
+	});
+	await t.throwsAsync(() => tempy.write(readable), {
+		instanceOf: Error,
+		message: 'Catch me if you can!'
+	});
+});
+
+test('.writeSync()', t => {
+	t.is(fs.readFileSync(tempy.writeSync('unicorn'), 'utf8'), 'unicorn');
+});
+
 test('.root', t => {
 	t.true(tempy.root.length > 0);
 	t.true(path.isAbsolute(tempy.root));
+
 	t.throws(() => {
 		tempy.root = 'foo';
 	});

--- a/test.js
+++ b/test.js
@@ -46,18 +46,33 @@ test('.cleanAsync()', async t => {
 	});
 });
 
-test('.job()', t => {
-	t.true(tempy.job(directory => pathExists.sync(directory)));
+test('.jobDirectory()', t => {
+	t.true(tempy.jobDirectory(directory => pathExists.sync(directory)));
 
-	const deleleDirectory = tempy.job(directory => directory);
+	const deleleDirectory = tempy.jobDirectory(directory => directory);
 	t.false(pathExists.sync(deleleDirectory));
 });
 
-test('.jobAsync()', async t => {
-	t.true(await tempy.job(async directory => pathExists(directory)));
-	t.true(await tempy.job(directory => pathExists.sync(directory)));
+test('.jobDirectoryAsync()', async t => {
+	t.true(await tempy.jobDirectory(async directory => pathExists(directory)));
+	t.true(await tempy.jobDirectory(directory => pathExists.sync(directory)));
 
-	const deleleDirectory = await tempy.job(directory => directory);
+	const deleleDirectory = await tempy.jobDirectory(directory => directory);
+	t.false(await pathExists(deleleDirectory));
+});
+
+test('.jobFile()', t => {
+	t.true(tempy.jobFile(file => file.endsWith('custom-name.md'), {name: 'custom-name.md'}));
+
+	const deleleDirectory = tempy.jobFile(file => path.dirname(file), {name: 'custom-name.md'});
+	t.false(pathExists.sync(deleleDirectory));
+});
+
+test('.jobFileAsync()', async t => {
+	t.true(await tempy.jobFile(async file => file.endsWith('custom-name.md'), {name: 'custom-name.md'}));
+	t.true(await tempy.jobFile(file => file.endsWith('custom-name.md'), {name: 'custom-name.md'}));
+
+	const deleleDirectory = await tempy.jobFile(file => path.dirname(file), {name: 'custom-name.md'});
 	t.false(await pathExists(deleleDirectory));
 });
 

--- a/test.js
+++ b/test.js
@@ -8,15 +8,28 @@ test('.file()', t => {
 	t.true(tempy.file().includes(tmpdir()));
 	t.true(tempy.file({extension: 'png'}).endsWith('.png'));
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
-	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
+	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
+});
+
+test('.fileAsync()', async t => {
+	t.true((await tempy.fileAsync()).includes(tmpdir()));
+	t.true((await tempy.fileAsync({extension: 'png'})).endsWith('.png'));
+	t.true((await tempy.fileAsync({extension: '.png'})).endsWith('.png'));
+	t.true((await tempy.fileAsync({name: 'custom-name.md'})).endsWith('custom-name.md'));
+	t.false((await tempy.fileAsync({extension: '.png'})).endsWith('..png'));
 });
 
 test('.directory()', t => {
 	t.true(tempy.directory().includes(tmpdir()));
 });
 
+test('.directoryAsync()', async t => {
+	t.true((await tempy.directoryAsync()).includes(tmpdir()));
+});
+
 test('.clean()', t => {
+	tempy.directory();
 	const deleleDirectories = tempy.clean();
 	t.true(deleleDirectories.length > 0);
 	deleleDirectories.forEach(directory => {
@@ -24,7 +37,23 @@ test('.clean()', t => {
 	});
 });
 
-test('.job()', async t => {
+test('.cleanAsync()', async t => {
+	await tempy.directoryAsync();
+	const deleleDirectories = await tempy.cleanAsync();
+	t.true(deleleDirectories.length > 0);
+	deleleDirectories.forEach(directory => {
+		t.false(pathExists.sync(directory));
+	});
+});
+
+test('.job()', t => {
+	t.true(tempy.job(directory => pathExists.sync(directory)));
+
+	const deleleDirectory = tempy.job(directory => directory);
+	t.false(pathExists.sync(deleleDirectory));
+});
+
+test('.jobAsync()', async t => {
 	t.true(await tempy.job(async directory => pathExists(directory)));
 	t.true(await tempy.job(directory => pathExists.sync(directory)));
 
@@ -39,3 +68,5 @@ test('.root', t => {
 		tempy.root = 'foo';
 	});
 });
+
+// TODO Add test auto clean and disable auto clean


### PR DESCRIPTION
Closes #11
- [x] Documentation
- [x] TypeScript Definition
- [x] Add a new example
- [x] Remove element by element of `cacheDirectories`
- [x] Asynchronous & synchronous version
- [x] .clean()
- [x] .job()
- [x] Cleaning on exit
- [x] Process events `SIGINT`, `uncaughtException`, `SIGUSR1` and `SIGUSR2` should also trigger cleaning
- [x] Replace `fs.mkdirSync` to [make-dir](https://github.com/sindresorhus/make-dir)
- [x] Add option to disable cleanup on exit