### PR TITLE
add methods for writing data to temp file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import {MergeExclusive} from 'type-fest';
+import { exists } from 'fs';
 
 declare namespace tempy {
 	type Options = MergeExclusive<
@@ -109,6 +110,22 @@ declare const tempy: {
 	```
 	*/
 	writeSync(fileContent: string | Buffer | NodeJS.ReadableStream, options?: tempy.Options): string
+
+	
+	/**
+	Check whether a path exists inside the root temporary directory.
+	
+	@param tempPath - Path whose existence is to be checked for.
+	@returns `true` or `false` based on the existence of the temporary path.
+	@example
+	```
+	import tempy = require('tempy');
+
+	tempy.exists('unicorn/and/pegasus');
+	//=> false
+	```
+	*/
+	exists(tempPath: string)
 
 	/**
 	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,6 +92,8 @@ declare const tempy: {
 	@returns The file path of the temp file.
 	@example
 	```
+	import tempy = require('tempy');
+
 	tempy.writeSync('unicorn', 'rainbow/cake/pony');
 	//=> '/var/folders/_1/tk89k8215ts0rg0kmb096nj80000gn/T/4049f192-43e7-43b2-98d9-094e6760861b/rainbow/cake/pony'
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,20 +4,29 @@ declare namespace tempy {
 	type Options = MergeExclusive<
 		{
 			/**
-			_You usually won't need this option. Specify it only when actually needed._
-
-			File extension. Mutually exclusive with the `name` option.
+			Path of the temprary file. Mutually exclusive with the `extension` or `name` option.
+			Mutually exclusive with both `name` and `extension` option.
 			*/
-			readonly extension?: string;
+			readonly filePath?: string;
 		},
-		{
-			/**
-			_You usually won't need this option. Specify it only when actually needed._
-
-			Filename. Mutually exclusive with the `extension` option.
-			*/
-			readonly name?: string;
-		}
+		MergeExclusive<
+			{
+				/**
+				_You usually won't need this option. Specify it only when actually needed._
+	
+				File extension. Mutually exclusive with the `name` option.
+				*/
+				readonly extension?: string;
+			},
+			{
+				/**
+				_You usually won't need this option. Specify it only when actually needed._
+	
+				Filename. Mutually exclusive with the `extension` option.
+				*/
+				readonly name?: string;
+			}
+		>
 	>;
 }
 
@@ -25,7 +34,6 @@ declare const tempy: {
 	/**
 	Get a temporary file path you can write to.
 
-	@param filePath - Path of the temporary file.
 	@example
 	```
 	import tempy = require('tempy');
@@ -39,7 +47,10 @@ declare const tempy: {
 	tempy.file({name: 'unicorn.png'});
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/unicorn.png'
 
-	tempy.writeSync('rainbow', '/directo/ries', {name: 'custom-name.txt'})
+	tempy.file({filePath: 'fol/ders/unicorn.png'});
+	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/fol/dersunicorn.png'
+
+	tempy.writeSync('rainbow', {filePath: '/directo/ries/custom-name.txt'})
 	//=> '/tmp/directo/ries/custom-name.txt'
 
 	tempy.directory();
@@ -66,7 +77,6 @@ declare const tempy: {
 	Write string/buffer/stream to a random temp file.
 
 	@param fileContent - Data to write to the temp file.
-	@param filePath - Path of the temporary file.
 	@param options - Options to be passed to tempy.file().
 	@returns The file path of the temp file.
 
@@ -81,24 +91,23 @@ declare const tempy: {
 	//=> 'unicorn'
 	```
 	*/
-	write(fileContent: string | Buffer | NodeJS.ReadableStream, filePath?: string, options?: tempy.Options): Promise<string>;
+	write(fileContent: string | Buffer | NodeJS.ReadableStream, options?: tempy.Options): Promise<string>;
 
 	/**
 	Synchronously write string/buffer/stream to a random temp file.
 	
 	@param fileContent - Data to write to the temp file.
-	@param filePath - Path of the temporary file.
 	@param options - Options to be passed to tempy.file().
 	@returns The file path of the temp file.
 	@example
 	```
 	import tempy = require('tempy');
 
-	tempy.writeSync('unicorn', 'rainbow/cake/pony');
+	tempy.writeSync('unicorn', {filePath: 'rainbow/cake/pony'});
 	//=> '/var/folders/_1/tk89k8215ts0rg0kmb096nj80000gn/T/4049f192-43e7-43b2-98d9-094e6760861b/rainbow/cake/pony'
 	```
 	*/
-	writeSync(fileContent: string | Buffer | NodeJS.ReadableStream, filePath?: string, options?: tempy.Options): string
+	writeSync(fileContent: string | Buffer | NodeJS.ReadableStream, options?: tempy.Options): string
 
 	/**
 	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,12 +50,6 @@ declare const tempy: {
 
 	tempy.file({filePath: 'fol/ders/unicorn.png'});
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/fol/dersunicorn.png'
-
-	tempy.writeSync('rainbow', {filePath: '/directo/ries/custom-name.txt'})
-	//=> '/tmp/directo/ries/custom-name.txt'
-
-	tempy.directory();
-	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
 	```
 	*/
 	file(options?: tempy.Options): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,7 @@ declare const tempy: {
 	Get a temporary directory path. The directory is created for you.
 
 	@param directoryPath - Path of the temporary directory.
+	@param options - Options for the temporary directory
 	@example
 	```
 	import tempy = require('tempy');
@@ -71,7 +72,7 @@ declare const tempy: {
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
 	```
 	*/
-	directory(directoryPath?: string): string;
+	directory(directoryPath?: string, options?: {makeCwd: boolean}): string;
 
 	/**
 	Write string/buffer/stream to a random temp file.

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ declare const tempy: {
 	//=> false
 	```
 	*/
-	exists(tempPath: string)
+	exists(tempPath: string): boolean
 
 	/**
 	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ declare const tempy: {
 	/**
 	Get a temporary file path you can write to.
 
+	@param filePath - Path of the temporary file.
 	@example
 	```
 	import tempy = require('tempy');
@@ -38,6 +39,9 @@ declare const tempy: {
 	tempy.file({name: 'unicorn.png'});
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/f7f62bfd4e2a05f1589947647ed3f9ec/unicorn.png'
 
+	tempy.writeSync('rainbow', '/directo/ries', {name: 'custom-name.txt'})
+	//=> '/tmp/directo/ries/custom-name.txt'
+
 	tempy.directory();
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
 	```
@@ -47,6 +51,7 @@ declare const tempy: {
 	/**
 	Get a temporary directory path. The directory is created for you.
 
+	@param directoryPath - Path of the temporary directory.
 	@example
 	```
 	import tempy = require('tempy');
@@ -55,7 +60,43 @@ declare const tempy: {
 	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
 	```
 	*/
-	directory(): string;
+	directory(directoryPath?: string): string;
+
+	/**
+	Write string/buffer/stream to a random temp file.
+
+	@param fileContent - Data to write to the temp file.
+	@param filePath - Path of the temporary file.
+	@param options - Options to be passed to tempy.file().
+	@returns The file path of the temp file.
+
+	@example
+	```
+	import tempy = require('tempy');
+
+	let tempPath = await tempy.write('unicorn');
+	//=> '/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/2f3d094aec2cb1b93bb0f4cffce5ebd6'
+
+	fs.readFileSync(tempPath).toString();
+	//=> 'unicorn'
+	```
+	*/
+	write(fileContent: string | Buffer | NodeJS.ReadableStream, filePath?: string, options?: tempy.Options): Promise<string>;
+
+	/**
+	Synchronously write string/buffer/stream to a random temp file.
+	
+	@param fileContent - Data to write to the temp file.
+	@param filePath - Path of the temporary file.
+	@param options - Options to be passed to tempy.file().
+	@returns The file path of the temp file.
+	@example
+	```
+	tempy.writeSync('unicorn', 'rainbow/cake/pony');
+	//=> '/var/folders/_1/tk89k8215ts0rg0kmb096nj80000gn/T/4049f192-43e7-43b2-98d9-094e6760861b/rainbow/cake/pony'
+	```
+	*/
+	writeSync(fileContent: string | Buffer | NodeJS.ReadableStream, filePath?: string, options?: tempy.Options): string
 
 	/**
 	Get the root temporary directory path. For example: `/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T`.

--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ module.exports.file = options => {
 module.exports.directory = (directoryPath, options) => {
 	const directory = getPath(directoryPath);
 	makeDir.sync(directory);
-	if (options && options.makeCwd)
+	if (options && options.makeCwd) {
 		process.chdir(directory);
+	}
+
 	return directory;
 };
 
@@ -74,6 +76,10 @@ module.exports.writeSync = (fileContent, options) => {
 	const tempFile = module.exports.file(options);
 	fs.writeFileSync(tempFile, fileContent);
 	return tempFile;
+};
+
+module.exports.exists = tempPath => {
+	return fs.existsSync(path.join(tempDir, tempPath));
 };
 
 Object.defineProperty(module.exports, 'root', {

--- a/index.js
+++ b/index.js
@@ -33,9 +33,11 @@ module.exports.file = options => {
 	return getPath().replace(/$\\/, '') + (extension ? '.' + extension.replace(/^\./, '') : '');
 };
 
-module.exports.directory = directoryPath => {
+module.exports.directory = (directoryPath, options) => {
 	const directory = getPath(directoryPath);
 	makeDir.sync(directory);
+	if (options && options.makeCwd)
+		process.chdir(directory);
 	return directory;
 };
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,20 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const {promisify} = require('util');
 const uniqueString = require('unique-string');
 const tempDir = require('temp-dir');
+const isStream = require('is-stream');
+const makeDir = require('make-dir');
 
-const getPath = () => path.join(tempDir, uniqueString());
+const getPath = _path => path.join(tempDir, _path || uniqueString());
 
-module.exports.file = options => {
+module.exports.file = (filePath, options) => {
+	if (typeof filePath === 'object') {
+		options = filePath;
+		filePath = undefined;
+	}
+
 	options = {
 		extension: '',
 		...options
@@ -17,16 +25,61 @@ module.exports.file = options => {
 			throw new Error('The `name` and `extension` options are mutually exclusive');
 		}
 
-		return path.join(module.exports.directory(), options.name);
+		return path.join(module.exports.directory(filePath), options.name);
 	}
 
-	return getPath() + '.' + options.extension.replace(/^\./, '');
+	if (options.extension) {
+		options.extension = '.' + options.extension.replace(/^\./, '');
+	}
+
+	if (filePath) {
+		const splittedPath = filePath.split('/');
+		const fileName = splittedPath.pop();
+		return path.join(module.exports.directory(fileName ? path.dirname(filePath) : filePath), (fileName || uniqueString()) + options.extension);
+	}
+
+	return getPath().replace(/$\\/, '') + options.extension;
 };
 
-module.exports.directory = () => {
-	const directory = getPath();
-	fs.mkdirSync(directory);
+module.exports.directory = directoryPath => {
+	const directory = getPath(directoryPath);
+	makeDir.sync(directory);
 	return directory;
+};
+
+module.exports.write = async (fileContent, filePath, options) => {
+	const writeFileP = promisify(fs.writeFile);
+
+	const writeStream = async (filePath, fileContent) =>
+		new Promise((resolve, reject) => {
+			const writable = fs.createWriteStream(filePath);
+
+			fileContent
+				.on('error', error => {
+					// Be careful to reject before writable.end(), otherwise the writable's
+					// 'finish' event will fire first and we will resolve the promise
+					// before we reject it.
+					reject(error);
+					fileContent.unpipe(writable);
+					writable.end();
+				})
+				.pipe(writable)
+				.on('error', reject)
+				.on('finish', resolve);
+		});
+
+	const tempFile = module.exports.file(filePath, options);
+	const write = isStream(fileContent) ? writeStream : writeFileP;
+
+	await write(tempFile, fileContent);
+
+	return tempFile;
+};
+
+module.exports.writeSync = (fileContent, filePath, options) => {
+	const tempFile = module.exports.file(filePath, options);
+	fs.writeFileSync(tempFile, fileContent);
+	return tempFile;
 };
 
 Object.defineProperty(module.exports, 'root', {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,16 +1,14 @@
 import {expectType, expectError} from 'tsd';
 import tempy = require('.');
 
-(async () => {
-    const options: tempy.Options = {};
-    expectType<string>(tempy.directory());
-    expectType<string>(tempy.file());
-    expectType<string>(tempy.file({extension: 'png'}));
-    expectType<string>(tempy.file({name: 'afile.txt'}));
-    expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
-    expectError(tempy.file({name: 'file.txt', filePath: '/blah/blah/blah/file.txt'}));
-    expectType<string>(tempy.root);
-    expectType<string>(tempy.writeSync('hi there'));
-    expectType<string>(await tempy.write('hi there'));
-    expectType<boolean>(tempy.exists('any/directory'));
-})
+const options: tempy.Options = {};
+expectType<string>(tempy.directory());
+expectType<string>(tempy.file());
+expectType<string>(tempy.file({extension: 'png'}));
+expectType<string>(tempy.file({name: 'afile.txt'}));
+expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
+expectError(tempy.file({name: 'file.txt', filePath: '/blah/blah/blah/file.txt'}));
+expectType<string>(tempy.root);
+expectType<string>(tempy.writeSync('hi there'));
+expectType<string>(await tempy.write('hi there'));
+expectType<boolean>(tempy.exists('any/directory'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,4 +12,5 @@ import tempy = require('.');
     expectType<string>(tempy.root);
     expectType<string>(tempy.writeSync('hi there'));
     expectType<string>(await tempy.write('hi there'));
+    expectType<boolean>(tempy.exists('any/directory'));
 })

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,3 +8,5 @@ expectType<string>(tempy.file({extension: 'png'}));
 expectType<string>(tempy.file({name: 'afile.txt'}));
 expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
 expectType<string>(tempy.root);
+expectType<string>(tempy.writeSync('hi there'));
+(async () => {expectType<string>(await tempy.write('hi there'))});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,14 @@
 import {expectType, expectError} from 'tsd';
 import tempy = require('.');
 
-const options: tempy.Options = {};
-expectType<string>(tempy.directory());
-expectType<string>(tempy.file());
-expectType<string>(tempy.file({extension: 'png'}));
-expectType<string>(tempy.file({name: 'afile.txt'}));
-expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
-expectType<string>(tempy.root);
-expectType<string>(tempy.writeSync('hi there'));
-(async () => {expectType<string>(await tempy.write('hi there'))});
+(async () => {
+    const options: tempy.Options = {};
+    expectType<string>(tempy.directory());
+    expectType<string>(tempy.file());
+    expectType<string>(tempy.file({extension: 'png'}));
+    expectType<string>(tempy.file({name: 'afile.txt'}));
+    expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
+    expectType<string>(tempy.root);
+    expectType<string>(tempy.writeSync('hi there'));
+    expectType<string>(await tempy.write('hi there'));
+})

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,6 +8,7 @@ import tempy = require('.');
     expectType<string>(tempy.file({extension: 'png'}));
     expectType<string>(tempy.file({name: 'afile.txt'}));
     expectError(tempy.file({extension: 'png', name: 'afile.txt'}));
+    expectError(tempy.file({name: 'file.txt', filePath: '/blah/blah/blah/file.txt'}));
     expectType<string>(tempy.root);
     expectType<string>(tempy.writeSync('hi there'));
     expectType<string>(await tempy.write('hi there'));

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
 		"make-dir": "^3.0.0",
 		"temp-dir": "^1.0.0",
 		"type-fest": "^0.3.1",
-		"unique-string": "^1.0.0",
-		"util": "^0.12.0"
+		"unique-string": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,12 @@
 		"uniq"
 	],
 	"dependencies": {
+		"is-stream": "^2.0.0",
+		"make-dir": "^3.0.0",
 		"temp-dir": "^1.0.0",
 		"type-fest": "^0.3.1",
-		"unique-string": "^1.0.0"
+		"unique-string": "^1.0.0",
+		"util": "^0.12.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,15 @@ tempy.directory();
 
 ## API
 
-### tempy.file([options])
+### tempy.file([filePath, options])
 
 Get a temporary file path you can write to.
+
+#### filePath
+
+Type: `String`  
+
+Path of the the temporary file.
 
 #### options
 
@@ -53,9 +59,15 @@ Type: `string`
 
 Filename. Mutually exclusive with the `extension` option.
 
-### tempy.directory()
+### tempy.directory([directoryPath])
 
 Get a temporary directory path. The directory is created for you.
+
+#### directoryPath
+
+Type: `String`
+
+Path of the temporary directory.
 
 ### tempy.root
 

--- a/readme.md
+++ b/readme.md
@@ -31,21 +31,26 @@ tempy.directory();
 
 ## API
 
-### tempy.file([filePath, options])
+### tempy.file([options])
 
 Get a temporary file path you can write to.
-
-#### filePath
-
-Type: `String`  
-
-Path of the the temporary file.
 
 #### options
 
 Type: `Object`
 
 *You usually won't need either the `extension` or `name` option. Specify them only when actually needed.*
+
+##### filePath
+
+Type: `string`
+
+Path of the temporary file.
+
+Use it when you need the temporary file to have a specific path and name inside the root temporary directory.
+For instance when you want to copy a directory to temporary directory maintaining the exact structure.
+
+Mutually exclusive with both `name` and `extension` option.
 
 ##### extension
 
@@ -68,6 +73,18 @@ Get a temporary directory path. The directory is created for you.
 Type: `String`
 
 Path of the temporary directory.
+
+### tempy.write(fileContent[[, options]](#options))
+
+Write string/buffer/stream to a random temp file.
+
+#### fileContent
+
+Contents of the temporary file.
+
+### tempy.writeSync(fileContent[[, options]](#options))
+
+Same as tempy.write but synchronous.
 
 ### tempy.root
 

--- a/test.js
+++ b/test.js
@@ -17,10 +17,16 @@ test('.file()', t => {
 test('.directory()', t => {
 	t.true(tempy.directory().includes(tmpdir()));
 	t.true(tempy.directory('/rainbow').endsWith('rainbow'));
+	const tempDir = tempy.directory('adirectory', {makeCwd: true});
+	t.deepEqual(process.cwd(), tempDir);
 });
 
 test('.write()', async t => {
-	const tempPath = await tempy.write('rainbow');
+	let tempPath = await tempy.write('rainbow');
+	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
+	tempPath = await tempy.write(fs.readFileSync(tempPath));
+	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
+	tempPath = await tempy.write(fs.createReadStream(tempPath));
 	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
 });
 
@@ -29,6 +35,13 @@ test('.writeSync()', t => {
 	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
 	t.true(tempPath.endsWith('custom-name.txt'));
 	t.true(tempPath.includes('/directo/ries'));
+});
+
+test('.exists()', t => {
+	const tempFile = tempy.writeSync('anything....', {filePath: 'temp/dir/file'});
+	t.true(tempy.exists('temp/dir/file'));
+	fs.unlinkSync(tempFile);
+	t.false(tempy.exists('temp/dir/file'));
 });
 
 test('.root', t => {

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import {tmpdir} from 'os';
 import test from 'ava';
 import tempy from '.';
@@ -9,10 +10,26 @@ test('.file()', t => {
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
+	t.true(tempy.file('/rainbow/unicorns').endsWith('/rainbow/unicorns'));
+	t.true(tempy.file('/directo/ries', {extension: '.txt'}).endsWith('ries.txt'));
+	t.true(tempy.file('/directo/ries', {name: 'text'}).endsWith('/directo/ries/text'));
 });
 
 test('.directory()', t => {
 	t.true(tempy.directory().includes(tmpdir()));
+	t.true(tempy.directory('/rainbow').endsWith('rainbow'));
+});
+
+test('.write()', async t => {
+	const tempPath = await tempy.write('rainbow');
+	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
+});
+
+test('.writeSync()', t => {
+	const tempPath = tempy.writeSync('rainbow', '/directo/ries', {name: 'custom-name.txt'});
+	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
+	t.true(tempPath.endsWith('custom-name.txt'));
+	t.true(tempPath.includes('/directo/ries'));
 });
 
 test('.root', t => {

--- a/test.js
+++ b/test.js
@@ -10,9 +10,8 @@ test('.file()', t => {
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
-	t.true(tempy.file('/rainbow/unicorns').endsWith('/rainbow/unicorns'));
-	t.true(tempy.file('/directo/ries', {extension: '.txt'}).endsWith('ries.txt'));
-	t.true(tempy.file('/directo/ries', {name: 'text'}).endsWith('/directo/ries/text'));
+	t.true(tempy.file({filePath: '/rainbow/unicorns'}).endsWith('/rainbow/unicorns'));
+	t.true(tempy.file({filePath: '/directo/ries/text'}).endsWith('ries/text'));
 });
 
 test('.directory()', t => {
@@ -26,7 +25,7 @@ test('.write()', async t => {
 });
 
 test('.writeSync()', t => {
-	const tempPath = tempy.writeSync('rainbow', '/directo/ries', {name: 'custom-name.txt'});
+	const tempPath = tempy.writeSync('rainbow', {filePath: '/directo/ries/custom-name.txt'});
 	t.deepEqual(fs.readFileSync(tempPath).toString(), 'rainbow');
 	t.true(tempPath.endsWith('custom-name.txt'));
 	t.true(tempPath.includes('/directo/ries'));


### PR DESCRIPTION
everything is almost done.

I've modified file and drectory methods to help in write and writeSync.
Just, the `filePath` argument which file function is accepting is getting appended to the the random path generated unlike what happens in temp-write, because using file method one can already specify the file name.

Or should I not make these changes to file and directory method. Just do all that in write and writeSync only? @sindresorhus 

**EDIT:** not asking this anymore