### PR TITLE
Upgrade engines field to Node.js >=8.3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=8.3"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This package have never actually supported Node.js 8.0.0 - 8.2.1 so this shouldn't be a breaking change, the de facto oldest supported Node.js version have always been 8.3.0.