### PR TITLE
Fix `tempy.file()` always adds extension-dot `.` even if no extension is given

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const getPath = () => path.join(tempDir, uniqueString());
 
 module.exports.file = options => {
 	options = {
-		extension: '',
 		...options
 	};
 
@@ -20,7 +19,7 @@ module.exports.file = options => {
 		return path.join(module.exports.directory(), options.name);
 	}
 
-	return getPath() + '.' + options.extension.replace(/^\./, '');
+	return getPath() + (options.extension == null ? '' : '.' + options.extension.replace(/^\./, ''));
 };
 
 module.exports.directory = () => {

--- a/index.js
+++ b/index.js
@@ -12,14 +12,14 @@ module.exports.file = options => {
 	};
 
 	if (options.name) {
-		if (options.extension != null) {
+		if (options.extension !== undefined && options.extension !== null) {
 			throw new Error('The `name` and `extension` options are mutually exclusive');
 		}
 
 		return path.join(module.exports.directory(), options.name);
 	}
 
-	return getPath() + (options.extension == null ? '' : '.' + options.extension.replace(/^\./, ''));
+	return getPath() + (options.extension === undefined || options.extension === null ? '' : '.' + options.extension.replace(/^\./, ''));
 };
 
 module.exports.directory = () => {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports.file = options => {
 	};
 
 	if (options.name) {
-		if (options.extension) {
+		if (options.extension != null) {
 			throw new Error('The `name` and `extension` options are mutually exclusive');
 		}
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,9 @@ import tempy from '.';
 
 test('.file()', t => {
 	t.true(tempy.file().includes(tmpdir()));
+	t.false(tempy.file().endsWith('.'));
+	t.false(tempy.file({extension: undefined}).endsWith('.'));
+	t.false(tempy.file({extension: null}).endsWith('.'));
 	t.true(tempy.file({extension: 'png'}).endsWith('.png'));
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));

--- a/test.js
+++ b/test.js
@@ -12,10 +12,22 @@ test('.file()', t => {
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
-	t.throws(() => tempy.file({name: 'custom-name.md', extension: '.ext'}));
-	t.throws(() => tempy.file({name: 'custom-name.md', extension: ''}));
-	t.notThrows(() => tempy.file({name: 'custom-name.md', extension: undefined}));
-	t.notThrows(() => tempy.file({name: 'custom-name.md', extension: null}));
+
+	t.throws(() => {
+		tempy.file({name: 'custom-name.md', extension: '.ext'});
+	});
+
+	t.throws(() => {
+		tempy.file({name: 'custom-name.md', extension: ''});
+	});
+
+	t.notThrows(() => {
+		tempy.file({name: 'custom-name.md', extension: undefined});
+	});
+
+	t.notThrows(() => {
+		tempy.file({name: 'custom-name.md', extension: null});
+	});
 });
 
 test('.directory()', t => {

--- a/test.js
+++ b/test.js
@@ -12,6 +12,10 @@ test('.file()', t => {
 	t.true(tempy.file({extension: '.png'}).endsWith('.png'));
 	t.false(tempy.file({extension: '.png'}).endsWith('..png'));
 	t.true(tempy.file({name: 'custom-name.md'}).endsWith('custom-name.md'));
+	t.throws(() => tempy.file({name: 'custom-name.md', extension: '.ext'}));
+	t.throws(() => tempy.file({name: 'custom-name.md', extension: ''}));
+	t.notThrows(() => tempy.file({name: 'custom-name.md', extension: undefined}));
+	t.notThrows(() => tempy.file({name: 'custom-name.md', extension: null}));
 });
 
 test('.directory()', t => {


### PR DESCRIPTION
Without either `options.name` or `options.extension`,  
`tempy.file()` returns a filename with trailing `.` .

```javascript
> tempy.file();
/tmp/4271ee202f7f5382cb8d1226c8dc89a4.
```

According to `readme.md`, this is not expected.

For now, skip `.` if the extension is nullish (`undefined` or `null`).  
Other falsy (but non-nullish) values (e.g. `false`, `0`, `NaN`, `""`) would be intended.
