### PR TITLE
Make `.task` methods reflect return values from callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ declare namespace tempy {
 	/**
 	The temporary path created by the function. Can be asynchronous.
 	*/
-	type TaskCallback = (tempPath: string) => Promise<void> | void;
+	type TaskCallback<ReturnValueType> = (tempPath: string) => Promise<ReturnValueType> | ReturnValueType;
 }
 
 declare const tempy: {
@@ -59,7 +59,7 @@ declare const tempy: {
 		});
 		```
 		*/
-		task: (callback: tempy.TaskCallback, options?: tempy.FileOptions) => Promise<void>;
+		task: <ReturnValueType>(callback: tempy.TaskCallback<ReturnValueType>, options?: tempy.FileOptions) => Promise<ReturnValueType>;
 
 		/**
 		Get a temporary file path you can write to.
@@ -99,7 +99,7 @@ declare const tempy: {
 		})
 		```
 		*/
-		task: (callback: tempy.TaskCallback, options?: tempy.DirectoryOptions) => Promise<void>;
+		task: <ReturnValueType>(callback: tempy.TaskCallback<ReturnValueType>, options?: tempy.DirectoryOptions) => Promise<ReturnValueType>;
 
 		/**
 		Get a temporary directory path. The directory is created for you.
@@ -133,7 +133,7 @@ declare const tempy: {
 		});
 		```
 		*/
-		task: (fileContent: string | Buffer | TypedArray | DataView | NodeJS.ReadableStream, callback: tempy.TaskCallback, options?: tempy.FileOptions) => Promise<void>;
+		task: <ReturnValueType>(fileContent: string | Buffer | TypedArray | DataView | NodeJS.ReadableStream, callback: tempy.TaskCallback<ReturnValueType>, options?: tempy.FileOptions) => Promise<ReturnValueType>;
 
 		/**
 		Write data to a random temp file.

--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ const writeStream = async (filePath, data) => pipeline(data, fs.createWriteStrea
 const createTask = (tempyFunction, {extraArguments = 0} = {}) => async (...arguments_) => {
 	const [callback, options] = arguments_.slice(extraArguments);
 	const result = await tempyFunction(...arguments_.slice(0, extraArguments), options);
-	await callback(result);
+	const returnValue = await callback(result);
 	await del(result, {force: true});
+	return returnValue;
 };
 
 module.exports.file = options => {

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Get a temporary file path you can write to.
 
 ### tempy.file.task(callback, options?)
 
-The `callback` resolves with a temporary file path you can write to. The file is automatically cleaned up after the callback is executed. Returns a promise that resolves after the callback is executed and the file is cleaned up.
+The `callback` resolves with a temporary file path you can write to. The file is automatically cleaned up after the callback is executed. Returns a promise that resolves with the return value of the callback after it is executed and the file is cleaned up.
 
 #### callback
 
@@ -69,7 +69,7 @@ Get a temporary directory path. The directory is created for you.
 
 ### tempy.directory.task(callback, options?)
 
-The `callback` resolves with a temporary directory path you can write to. The directory is automatically cleaned up after the callback is executed. Returns a promise that resolves after the callback is executed and the directory is cleaned up.
+The `callback` resolves with a temporary directory path you can write to. The directory is automatically cleaned up after the callback is executed. Returns a promise that resolves with the return value of the callback after it is executed and the directory is cleaned up.
 
 ##### callback
 
@@ -97,7 +97,7 @@ Write data to a random temp file.
 
 ### tempy.write.task(fileContent, callback, options?)
 
-Write data to a random temp file. The file is automatically cleaned up after the callback is executed. Returns a promise that resolves after the callback is executed and the file is cleaned up.
+Write data to a random temp file. The file is automatically cleaned up after the callback is executed. Returns a promise that resolves with the return value of the callback after it is executed and the file is cleaned up.
 
 ##### fileContent
 

--- a/test.js
+++ b/test.js
@@ -36,10 +36,11 @@ test('.file()', t => {
 
 test('.file.task()', async t => {
 	let temporaryFilePath;
-	await tempy.file.task(async temporaryFile => {
+	t.is(await tempy.file.task(async temporaryFile => {
 		await touch(temporaryFile);
 		temporaryFilePath = temporaryFile;
-	});
+		return temporaryFile;
+	}), temporaryFilePath);
 	t.false(await pathExists(temporaryFilePath));
 });
 
@@ -52,9 +53,10 @@ test('.directory()', t => {
 
 test('.directory.task()', async t => {
 	let temporaryDirectoryPath;
-	await tempy.directory.task(async temporaryDirectory => {
+	t.is(await tempy.directory.task(async temporaryDirectory => {
 		temporaryDirectoryPath = temporaryDirectory;
-	});
+		return temporaryDirectory;
+	}), temporaryDirectoryPath);
 	t.false(await pathExists(temporaryDirectoryPath));
 });
 
@@ -66,9 +68,10 @@ test('.write(string)', async t => {
 
 test('.write.task(string)', async t => {
 	let temporaryFilePath;
-	await tempy.write.task('', async temporaryFile => {
+	t.is(await tempy.write.task('', async temporaryFile => {
 		temporaryFilePath = temporaryFile;
-	});
+		return temporaryFile;
+	}), temporaryFilePath);
 	t.false(await pathExists(temporaryFilePath));
 });
 


### PR DESCRIPTION
Fixes: #28 