### PR TITLE
Recursive mkdir to allow path.sep in a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ export const temporaryFileTask = async (callback, options) => runTask(temporaryF
 
 export function temporaryDirectory({prefix = ''} = {}) {
 	const directory = getPath(prefix);
-	fs.mkdirSync(directory);
+	fs.mkdirSync(directory, {recursive: true});
 	return directory;
 }
 

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ test('.directory()', t => {
 
 	t.true(temporaryDirectory().includes(tempDir));
 	t.true(path.basename(temporaryDirectory({prefix})).startsWith(prefix.split(path.sep)[1]));
-	t.true(path.dirname(temporaryDirectory({prefix})).split(path.sep).pop() === (prefix.split(path.sep)[0]));
+	t.true(path.dirname(temporaryDirectory({prefix})).split(path.sep).pop() === prefix.split(path.sep)[0]);
 });
 
 test('.directory.task()', async t => {

--- a/test.js
+++ b/test.js
@@ -68,10 +68,16 @@ test('.task() - cleans up even if callback throws', async t => {
 });
 
 test('.directory()', t => {
-	const prefix = 'name_';
+	let prefix = 'name_';
 
 	t.true(temporaryDirectory().includes(tempDir));
 	t.true(path.basename(temporaryDirectory({prefix})).startsWith(prefix));
+
+	prefix = path.join('parent', 'name_');
+
+	t.true(temporaryDirectory().includes(tempDir));
+	t.true(path.basename(temporaryDirectory({prefix})).startsWith(prefix.split(path.sep)[1]));
+	t.true(path.dirname(temporaryDirectory({prefix})).split(path.sep).pop() === (prefix.split(path.sep)[0]));
 });
 
 test('.directory.task()', async t => {


### PR DESCRIPTION
From https://github.com/sindresorhus/tempy/issues/43:

> Prefix which includes a `path.sep` fails.
> 
> ### Repro
> This fails as the path will include a `path.sep`:
> ```js
> const uuid = 'xyz';
> const prefixForRun = path.join('runs', `run_${uuid}`);
> const outputFolder = temporaryDirectory({prefix: prefixForRun});
> ```
> 
> This call results in a path of:
> '/private/var/folders/6t/frtzt7q96fv9xjqp3knl3vqh0000gn/T/runs/run_xyz'
> 
> The mkdir for `run_xyz` fails since the parent, `/private/var/folders/6t/frtzt7q96fv9xjqp3knl3vqh0000gn/T/runs/`, does not exist.
> 
> ### Error
> ```
> Error: ENOENT: no such file or directory, mkdir '/private/var/folders/6t/frtzt7q96fv9xjqp3knl3vqh0000gn/T/runs/run_xyz'
>     at Object.mkdirSync (node:fs:1324:3)
> ```
> 
> ### Solution
> In mkdir, add the `{recursive: true}` option.
> 
> ### Discussion
> Incidentally, fixing this gives an indirect method of https://github.com/sindresorhus/tempy/issues/35, as my intention was similar. To organize my temp files/folders for later cleanup, I was adding a parent folder to my requested temp folder.

Closes https://github.com/sindresorhus/tempy/issues/43